### PR TITLE
add setupPlayerItemWithUrl

### DIFF
--- a/HysteriaPlayer/HysteriaPlayer.h
+++ b/HysteriaPlayer/HysteriaPlayer.h
@@ -116,6 +116,7 @@ PlayerShuffleMode;
  @method setupPlayerItem:
  */
 - (void)setupPlayerItem:(NSString *)url Order:(NSUInteger)index;
+- (void)setupPlayerItemWithUrl:(NSURL *)url Order:(NSUInteger)index;
 - (void)fetchAndPlayPlayerItem: (NSUInteger )startAt;
 - (void)removeAllItems;
 - (void)removeQueuesAtPlayer;

--- a/HysteriaPlayer/HysteriaPlayer.m
+++ b/HysteriaPlayer/HysteriaPlayer.m
@@ -305,7 +305,12 @@ static dispatch_once_t onceToken;
 
 - (void)setupPlayerItem:(NSString *)url Order:(NSUInteger)index
 {
-    AVPlayerItem *item = [AVPlayerItem playerItemWithURL:[NSURL URLWithString:url]];
+    [self setupPlayerItemWithUrl:[NSURL URLWithString:url] Order:index];
+}
+
+- (void)setupPlayerItemWithUrl:(NSURL *)url Order:(NSUInteger)index
+{
+    AVPlayerItem *item = [AVPlayerItem playerItemWithURL:url];
     if (!item)
         return;
     
@@ -317,6 +322,7 @@ static dispatch_once_t onceToken;
         [self insertPlayerItem:item];
     });
 }
+
 
 - (BOOL)findSourceInPlayerItems:(NSUInteger)index
 {


### PR DESCRIPTION
I think that sometimes it is necessary to use NSURL directly, such as when a local file is used or downloaded to the application directory. 

I hope this small change does not affect the rest
