### PR TITLE
Fixed player instance deprecating.

### DIFF
--- a/HysteriaPlayer/HysteriaPlayer.m
+++ b/HysteriaPlayer/HysteriaPlayer.m
@@ -811,6 +811,7 @@ static dispatch_once_t onceToken;
 {
     NSError *error;
     tookAudioFocus = NO;
+    [[AVAudioSession sharedInstance] setCategory:nil error:&error];
     [[AVAudioSession sharedInstance] setActive:NO error:&error];
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
     [[NSNotificationCenter defaultCenter]removeObserver:self name:AVPlayerItemDidPlayToEndTimeNotification object:nil];


### PR DESCRIPTION
Deactivating an audio session that has running I/O. All I/O should be stopped or paused prior to deactivating the audio session.