### PR TITLE
Stop repeating playing when repeat mode 

### DIFF
--- a/HysteriaPlayer/HysteriaPlayer.m
+++ b/HysteriaPlayer/HysteriaPlayer.m
@@ -515,8 +515,9 @@ static dispatch_once_t onceToken;
                 if ([self.delegate respondsToSelector:@selector(hysteriaPlayerDidReachEnd)]) {
                     [self.delegate hysteriaPlayerDidReachEnd];
                 }
+            } else {
+                [self fetchAndPlayPlayerItem:0];
             }
-            [self fetchAndPlayPlayerItem:0];
         }
     }
 }


### PR DESCRIPTION
I removed my play items array when reached "hysteriaPlayerDidReachEnd" delegate method. then app crashed since it continue to get the first item even I set repeat mode to OFF.

not sure If my do it correctly. thank you.