### PR TITLE
AVPlayerItem cannot service a seek request

### DIFF
--- a/HysteriaPlayer/HysteriaPlayer.m
+++ b/HysteriaPlayer/HysteriaPlayer.m
@@ -326,10 +326,12 @@ static dispatch_once_t onceToken;
     for (AVPlayerItem *item in self.playerItems) {
         NSInteger checkIndex = [[self getHysteriaIndex:item] integerValue];
         if (checkIndex == index) {
-            [item seekToTime:kCMTimeZero completionHandler:^(BOOL finished) {
-                [self insertPlayerItem:item];
-            }];
-            return YES;
+            if (item.status == AVPlayerItemStatusReadyToPlay) {
+                [item seekToTime:kCMTimeZero completionHandler:^(BOOL finished) {
+                    [self insertPlayerItem:item];
+                }];
+                return YES;
+            }
         }
     }
     return NO;


### PR DESCRIPTION
NSInvalidArgumentException
AVPlayerItem cannot service a seek request with a completion handler until its status is AVPlayerItemStatusReadyToPlay.

0	CoreFoundation	0x0000000180b76e38	___exceptionPreprocess + 124
1	libobjc.A.dylib	0x00000001801dbf80	objc_exception_throw + 56
2	AVFoundation	0x0000000187237820	-[AVPlayerItem seekToTime:toleranceBefore:toleranceAfter:completionHandler:] + 864
3	AVFoundation	0x00000001872374b4	-[AVPlayerItem seekToTime:completionHandler:] + 92