### PR TITLE
Add shouldChangePlayerItemAtIndex delegate method

### DIFF
--- a/HysteriaPlayer/HysteriaPlayer.h
+++ b/HysteriaPlayer/HysteriaPlayer.h
@@ -49,7 +49,8 @@ typedef NS_ENUM(NSInteger, HysteriaPlayerFailed) {
 @protocol HysteriaPlayerDelegate <NSObject>
 
 @optional
-- (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer willChangePlayerItemAtIndex:(NSInteger)index;
+- (BOOL)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer shouldChangePlayerItemAtIndex:(NSInteger)index;
+- (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer willChangePlayerItemAtIndex:(NSInteger)index DEPRECATED_MSG_ATTRIBUTE("deprecated since 2.2.5 version");
 - (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer didChangeCurrentItem:(AVPlayerItem *)item;
 - (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer didEvictCurrentItem:(AVPlayerItem *)item;
 - (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer rateDidChange:(float)rate;

--- a/HysteriaPlayerObjcExample/HyseteriaSamples/ViewController.m
+++ b/HysteriaPlayerObjcExample/HyseteriaSamples/ViewController.m
@@ -140,9 +140,10 @@
     NSLog(@"player rate changed");
 }
 
-- (void)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer willChangePlayerItemAtIndex:(NSInteger)index
+- (BOOL)hysteriaPlayer:(HysteriaPlayer *)hysteriaPlayer shouldChangePlayerItemAtIndex:(NSInteger)index
 {
     NSLog(@"index: %li is about to play", index);
+    return YES;
 }
 
 #pragma mark - HysteriaPlayerDataSource


### PR DESCRIPTION
Ask the delegator should change the new index. It makes playback more flexible.
HysteriaPlayer will play a new index always when the delegator is not to implement `shouldChangePlayerItemAtIndex:` delegate method. 